### PR TITLE
Simplify error handling and remove redundant methods

### DIFF
--- a/fabric/plugins/module_utils/pureport_client.py
+++ b/fabric/plugins/module_utils/pureport_client.py
@@ -4,17 +4,13 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from traceback import format_exc
-
 try:
     from pureport.api.client import Client, API_URL
-    from pureport.exception.api import ClientHttpException
     HAS_PUREPORT_CLIENT = True
 except ImportError:
     HAS_PUREPORT_CLIENT = False
     API_URL = None
     Client = None
-    ClientHttpException = None
 
 
 def get_client_argument_spec():
@@ -50,14 +46,11 @@ def get_client(module):
     if not HAS_PUREPORT_CLIENT:
         module.fail_json(msg='pureport-client required for this module')
     client = Client(module.params.get('api_base_url'))
-    try:
-        client.login(
-            key=module.params.get('api_key'),
-            secret=module.params.get('api_secret'),
-            access_token=module.params.get('api_access_token')
-        )
-    except ClientHttpException as e:
-        module.fail_json(msg=e.response.text, exception=format_exc())
+    client.login(
+        key=module.params.get('api_key'),
+        secret=module.params.get('api_secret'),
+        access_token=module.params.get('api_access_token')
+    )
     return client
 
 

--- a/fabric/plugins/modules/access_token_info.py
+++ b/fabric/plugins/modules/access_token_info.py
@@ -73,21 +73,6 @@ except ImportError:
     ClientHttpException = None
 
 
-def get_access_token(module):
-    """
-    Get the access token
-    :param AnsibleModule module: the ansible module
-    :rtype: str
-    """
-    if not HAS_PUREPORT_CLIENT:
-        module.fail_json(msg='pureport-client required for this module')
-    client = Client(module.params.get('api_base_url'))
-    try:
-        return client.login(module.params.get('api_key'), module.params.get('api_secret'))
-    except ClientHttpException as e:
-        module.fail_json(msg=e.response.text, exception=format_exc())
-
-
 def main():
     argument_spec = dict(
         api_base_url=dict(type='str'),
@@ -99,7 +84,13 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=mutually_exclusive
     )
-    module.exit_json(access_token=get_access_token(module))
+    if not HAS_PUREPORT_CLIENT:
+        module.fail_json(msg='pureport-client required for this module')
+    client = Client(module.params.get('api_base_url'))
+    try:
+        module.exit_json(access_token=client.login(module.params.get('api_key'), module.params.get('api_secret')))
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/accounts_info.py
+++ b/fabric/plugins/modules/accounts_info.py
@@ -109,19 +109,6 @@ from ..module_utils.pureport_client import \
     get_client
 
 
-def find_accounts(module):
-    """
-    List accounts
-    :param AnsibleModule module: the ansible module
-    """
-    client = get_client(module)
-    try:
-        accounts = client.accounts.list()
-        module.exit_json(accounts=[camel_dict_to_snake_dict(account) for account in accounts])
-    except ClientHttpException as e:
-        module.fail_json(msg=e.response.text, exception=format_exc())
-
-
 def main():
     argument_spec = dict()
     argument_spec.update(get_client_argument_spec())
@@ -132,7 +119,12 @@ def main():
         mutually_exclusive=mutually_exclusive,
         supports_check_mode=True
     )
-    find_accounts(module)
+    try:
+        client = get_client(module)
+        accounts = client.accounts.list()
+        module.exit_json(accounts=[camel_dict_to_snake_dict(account) for account in accounts])
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/aws_direct_connect_connection.py
+++ b/fabric/plugins/modules/aws_direct_connect_connection.py
@@ -160,6 +160,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.dict_transformations import \
     camel_dict_to_snake_dict, \
     snake_dict_to_camel_dict
+from traceback import format_exc
+try:
+    from pureport.exception.api import ClientHttpException
+except ImportError:
+    ClientHttpException = None
 
 from ..module_utils.pureport_client import \
     get_object_link, \
@@ -252,19 +257,22 @@ def main():
         required_one_of=required_one_of
     )
     # Using partials to fill in the method params
-    (
-        changed,
-        changed_connection,
-        argument_connection,
-        existing_connection
-    ) = connection_crud(
-        module,
-        partial(construct_connection, module)
-    )
-    module.exit_json(
-        changed=changed,
-        **camel_dict_to_snake_dict(changed_connection)
-    )
+    try:
+        (
+            changed,
+            changed_connection,
+            argument_connection,
+            existing_connection
+        ) = connection_crud(
+            module,
+            partial(construct_connection, module)
+        )
+        module.exit_json(
+            changed=changed,
+            **camel_dict_to_snake_dict(changed_connection)
+        )
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/azure_express_route_connection.py
+++ b/fabric/plugins/modules/azure_express_route_connection.py
@@ -130,6 +130,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.dict_transformations import \
     camel_dict_to_snake_dict, \
     snake_dict_to_camel_dict
+from traceback import format_exc
+try:
+    from pureport.exception.api import ClientHttpException
+except ImportError:
+    ClientHttpException = None
 
 from ..module_utils.pureport_client import \
     get_object_link, \
@@ -208,19 +213,22 @@ def main():
         required_one_of=required_one_of
     )
     # Using partials to fill in the method params
-    (
-        changed,
-        changed_connection,
-        argument_connection,
-        existing_connection
-    ) = connection_crud(
-        module,
-        partial(construct_connection, module)
-    )
-    module.exit_json(
-        changed=changed,
-        **camel_dict_to_snake_dict(changed_connection)
-    )
+    try:
+        (
+            changed,
+            changed_connection,
+            argument_connection,
+            existing_connection
+        ) = connection_crud(
+            module,
+            partial(construct_connection, module)
+        )
+        module.exit_json(
+            changed=changed,
+            **camel_dict_to_snake_dict(changed_connection)
+        )
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/cloud_regions_info.py
+++ b/fabric/plugins/modules/cloud_regions_info.py
@@ -91,19 +91,6 @@ from ..module_utils.pureport_client import \
     get_client
 
 
-def find_cloud_regions(module):
-    """
-    List cloud regions
-    :param AnsibleModule module: the ansible module
-    """
-    client = get_client(module)
-    try:
-        cloud_regions = client.cloud_regions.list()
-        module.exit_json(cloud_regions=[camel_dict_to_snake_dict(cloud_region) for cloud_region in cloud_regions])
-    except ClientHttpException as e:
-        module.fail_json(msg=e.response.text, exception=format_exc())
-
-
 def main():
     argument_spec = dict()
     argument_spec.update(get_client_argument_spec())
@@ -114,7 +101,12 @@ def main():
         mutually_exclusive=mutually_exclusive,
         supports_check_mode=True
     )
-    find_cloud_regions(module)
+    try:
+        client = get_client(module)
+        cloud_regions = client.cloud_regions.list()
+        module.exit_json(cloud_regions=[camel_dict_to_snake_dict(cloud_region) for cloud_region in cloud_regions])
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/cloud_services_info.py
+++ b/fabric/plugins/modules/cloud_services_info.py
@@ -126,19 +126,6 @@ from ..module_utils.pureport_client import \
     get_client
 
 
-def find_cloud_services(module):
-    """
-    List cloud services
-    :param AnsibleModule module: the ansible module
-    """
-    client = get_client(module)
-    try:
-        cloud_services = client.cloud_services.list()
-        module.exit_json(cloud_services=[camel_dict_to_snake_dict(cloud_service) for cloud_service in cloud_services])
-    except ClientHttpException as e:
-        module.fail_json(msg=e.response.text, exception=format_exc())
-
-
 def main():
     argument_spec = dict()
     argument_spec.update(get_client_argument_spec())
@@ -149,7 +136,12 @@ def main():
         mutually_exclusive=mutually_exclusive,
         supports_check_mode=True
     )
-    find_cloud_services(module)
+    try:
+        client = get_client(module)
+        cloud_services = client.cloud_services.list()
+        module.exit_json(cloud_services=[camel_dict_to_snake_dict(cloud_service) for cloud_service in cloud_services])
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/facilities_info.py
+++ b/fabric/plugins/modules/facilities_info.py
@@ -151,20 +151,6 @@ def __format_facility(facility):
     return formatted_facility
 
 
-def find_facilities(module):
-    """
-    List facilities
-    :param AnsibleModule module: the ansible module
-    """
-    client = get_client(module)
-    try:
-        facilities = client.facilities.list()
-
-        module.exit_json(facilities=[__format_facility(facility) for facility in facilities])
-    except ClientHttpException as e:
-        module.fail_json(msg=e.response.text, exception=format_exc())
-
-
 def main():
     argument_spec = dict()
     argument_spec.update(get_client_argument_spec())
@@ -175,7 +161,12 @@ def main():
         mutually_exclusive=mutually_exclusive,
         supports_check_mode=True
     )
-    find_facilities(module)
+    try:
+        client = get_client(module)
+        facilities = client.facilities.list()
+        module.exit_json(facilities=[__format_facility(facility) for facility in facilities])
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/google_cloud_interconnect_connection.py
+++ b/fabric/plugins/modules/google_cloud_interconnect_connection.py
@@ -122,6 +122,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.dict_transformations import \
     camel_dict_to_snake_dict, \
     snake_dict_to_camel_dict
+from traceback import format_exc
+try:
+    from pureport.exception.api import ClientHttpException
+except ImportError:
+    ClientHttpException = None
 
 from ..module_utils.pureport_client import \
     get_object_link, \
@@ -199,19 +204,22 @@ def main():
         required_one_of=required_one_of
     )
     # Using partials to fill in the method params
-    (
-        changed,
-        changed_connection,
-        argument_connection,
-        existing_connection
-    ) = connection_crud(
-        module,
-        partial(construct_connection, module)
-    )
-    module.exit_json(
-        changed=changed,
-        **camel_dict_to_snake_dict(changed_connection)
-    )
+    try:
+        (
+            changed,
+            changed_connection,
+            argument_connection,
+            existing_connection
+        ) = connection_crud(
+            module,
+            partial(construct_connection, module)
+        )
+        module.exit_json(
+            changed=changed,
+            **camel_dict_to_snake_dict(changed_connection)
+        )
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/locations_info.py
+++ b/fabric/plugins/modules/locations_info.py
@@ -121,19 +121,6 @@ from ..module_utils.pureport_client import \
     get_client
 
 
-def find_locations(module):
-    """
-    List locations
-    :param AnsibleModule module: the ansible module
-    """
-    client = get_client(module)
-    try:
-        locations = client.locations.list()
-        module.exit_json(locations=[camel_dict_to_snake_dict(location) for location in locations])
-    except ClientHttpException as e:
-        module.fail_json(msg=e.response.text, exception=format_exc())
-
-
 def main():
     argument_spec = dict()
     argument_spec.update(get_client_argument_spec())
@@ -144,7 +131,12 @@ def main():
         mutually_exclusive=mutually_exclusive,
         supports_check_mode=True
     )
-    find_locations(module)
+    try:
+        client = get_client(module)
+        locations = client.locations.list()
+        module.exit_json(locations=[camel_dict_to_snake_dict(location) for location in locations])
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/networks_info.py
+++ b/fabric/plugins/modules/networks_info.py
@@ -90,20 +90,6 @@ from ..module_utils.pureport_client import \
     get_account_id
 
 
-def find_networks(module):
-    """
-    List networks
-    :param AnsibleModule module: the ansible module
-    """
-    client = get_client(module)
-    account_id = get_account_id(module)
-    try:
-        networks = client.accounts.networks(account_id).list()
-        module.exit_json(networks=[camel_dict_to_snake_dict(network) for network in networks])
-    except ClientHttpException as e:
-        module.fail_json(msg=e.response.text, exception=format_exc())
-
-
 def main():
     argument_spec = dict()
     argument_spec.update(get_client_argument_spec())
@@ -118,7 +104,12 @@ def main():
         required_one_of=required_one_of,
         supports_check_mode=True
     )
-    find_networks(module)
+    try:
+        client = get_client(module)
+        networks = client.accounts.networks(get_account_id(module)).list()
+        module.exit_json(networks=[camel_dict_to_snake_dict(network) for network in networks])
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/options_info.py
+++ b/fabric/plugins/modules/options_info.py
@@ -116,19 +116,6 @@ from ..module_utils.pureport_client import \
     get_client
 
 
-def find_options(module):
-    """
-    List options
-    :param AnsibleModule module: the ansible module
-    """
-    client = get_client(module)
-    try:
-        options = client.options.list(module.params.get('types'))
-        module.exit_json(options=options)
-    except ClientHttpException as e:
-        module.fail_json(msg=e.response.text, exception=format_exc())
-
-
 def main():
     argument_spec = dict()
     argument_spec.update(get_client_argument_spec())
@@ -161,7 +148,12 @@ def main():
         mutually_exclusive=mutually_exclusive,
         supports_check_mode=True
     )
-    find_options(module)
+    try:
+        client = get_client(module)
+        options = client.options.list(module.params.get('types'))
+        module.exit_json(options=options)
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/oracle_fast_connect_connection.py
+++ b/fabric/plugins/modules/oracle_fast_connect_connection.py
@@ -110,6 +110,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.dict_transformations import \
     camel_dict_to_snake_dict, \
     snake_dict_to_camel_dict
+from traceback import format_exc
+try:
+    from pureport.exception.api import ClientHttpException
+except ImportError:
+    ClientHttpException = None
 
 from ..module_utils.pureport_client import \
     get_object_link, \
@@ -205,19 +210,22 @@ def main():
         required_one_of=required_one_of
     )
     # Using partials to fill in the method params
-    (
-        changed,
-        changed_connection,
-        argument_connection,
-        existing_connection
-    ) = connection_crud(
-        module,
-        partial(construct_connection, module)
-    )
-    module.exit_json(
-        changed=changed,
-        **camel_dict_to_snake_dict(changed_connection)
-    )
+    try:
+        (
+            changed,
+            changed_connection,
+            argument_connection,
+            existing_connection
+        ) = connection_crud(
+            module,
+            partial(construct_connection, module)
+        )
+        module.exit_json(
+            changed=changed,
+            **camel_dict_to_snake_dict(changed_connection)
+        )
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/ports_info.py
+++ b/fabric/plugins/modules/ports_info.py
@@ -175,20 +175,6 @@ from ..module_utils.pureport_client import \
     get_account_id
 
 
-def find_ports(module):
-    """
-    List ports
-    :param AnsibleModule module: the ansible module
-    """
-    client = get_client(module)
-    account_id = get_account_id(module)
-    try:
-        ports = client.accounts.ports(account_id).list()
-        module.exit_json(ports=[camel_dict_to_snake_dict(port) for port in ports])
-    except ClientHttpException as e:
-        module.fail_json(msg=e.response.text, exception=format_exc())
-
-
 def main():
     argument_spec = dict()
     argument_spec.update(get_client_argument_spec())
@@ -203,7 +189,12 @@ def main():
         required_one_of=required_one_of,
         supports_check_mode=True
     )
-    find_ports(module)
+    try:
+        client = get_client(module)
+        ports = client.accounts.ports(get_account_id(module)).list()
+        module.exit_json(ports=[camel_dict_to_snake_dict(port) for port in ports])
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/site_ipsec_vpn_connection.py
+++ b/fabric/plugins/modules/site_ipsec_vpn_connection.py
@@ -376,6 +376,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.dict_transformations import \
     camel_dict_to_snake_dict, \
     snake_dict_to_camel_dict
+from traceback import format_exc
+try:
+    from pureport.exception.api import ClientHttpException
+except ImportError:
+    ClientHttpException = None
 
 from ..module_utils.pureport_client import \
     get_object_link, \
@@ -676,19 +681,22 @@ def main():
         required_one_of=required_one_of
     )
     # Using partials to fill in the method params
-    (
-        changed,
-        changed_connection,
-        argument_connection,
-        existing_connection
-    ) = connection_crud(
-        module,
-        partial(construct_connection, module)
-    )
-    module.exit_json(
-        changed=changed,
-        **camel_dict_to_snake_dict(changed_connection)
-    )
+    try:
+        (
+            changed,
+            changed_connection,
+            argument_connection,
+            existing_connection
+        ) = connection_crud(
+            module,
+            partial(construct_connection, module)
+        )
+        module.exit_json(
+            changed=changed,
+            **camel_dict_to_snake_dict(changed_connection)
+        )
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/supported_connections_info.py
+++ b/fabric/plugins/modules/supported_connections_info.py
@@ -210,21 +210,6 @@ from ..module_utils.pureport_client import \
     get_account_id
 
 
-def find_supported_connections(module):
-    """
-    List supported connections
-    :param AnsibleModule module: the ansible module
-    """
-    client = get_client(module)
-    account_id = get_account_id(module)
-    try:
-        supported_connections = client.accounts.supported_connections(account_id).list()
-        module.exit_json(supported_connections=[camel_dict_to_snake_dict(supported_connection)
-                                                for supported_connection in supported_connections])
-    except ClientHttpException as e:
-        module.fail_json(msg=e.response.text, exception=format_exc())
-
-
 def main():
     argument_spec = dict()
     argument_spec.update(get_client_argument_spec())
@@ -239,7 +224,13 @@ def main():
         required_one_of=required_one_of,
         supports_check_mode=True
     )
-    find_supported_connections(module)
+    try:
+        client = get_client(module)
+        supported_connections = client.accounts.supported_connections(get_account_id(module)).list()
+        module.exit_json(supported_connections=[camel_dict_to_snake_dict(supported_connection)
+                                                for supported_connection in supported_connections])
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/plugins/modules/supported_ports_info.py
+++ b/fabric/plugins/modules/supported_ports_info.py
@@ -162,24 +162,6 @@ from ..module_utils.pureport_client import \
     get_account_id
 
 
-def find_supported_ports(module):
-    """
-    List supported ports
-    :param AnsibleModule module: the ansible module
-    """
-    client = get_client(module)
-    account_id = get_account_id(module)
-    facility_id = get_object_id(module, 'facility_id', 'facility_href')
-    try:
-        supported_ports = client.accounts \
-            .supported_ports(account_id) \
-            .list(facility_id)
-        module.exit_json(supported_ports=[camel_dict_to_snake_dict(supported_port)
-                                          for supported_port in supported_ports])
-    except ClientHttpException as e:
-        module.fail_json(msg=e.response.text, exception=format_exc())
-
-
 def main():
     argument_spec = dict()
     argument_spec.update(get_client_argument_spec())
@@ -201,7 +183,15 @@ def main():
         required_one_of=required_one_of,
         supports_check_mode=True
     )
-    find_supported_ports(module)
+    try:
+        client = get_client(module)
+        supported_ports = client.accounts \
+            .supported_ports(get_account_id(module)) \
+            .list(get_object_id(module, 'facility_id', 'facility_href'))
+        module.exit_json(supported_ports=[camel_dict_to_snake_dict(supported_port)
+                                          for supported_port in supported_ports])
+    except ClientHttpException as e:
+        module.fail_json(msg=e.response.text, exception=format_exc())
 
 
 if __name__ == '__main__':

--- a/fabric/tests/playbooks/bin/create_playbook_vars.sh
+++ b/fabric/tests/playbooks/bin/create_playbook_vars.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 account_id=$(pureport accounts create '{"name": "Ansible Testing"}' | jq  -r '.id')
-pureport accounts consent "$account_id" accept > /dev/null
-network_id=$(pureport accounts networks "$account_id" create '{"name": "Ansible Testing"}' | jq  -r '.id')
-role_id=$(pureport accounts roles "$account_id" list | jq -r '.[0].id')
-api_key=$(pureport accounts api-keys "$account_id" create '{"name": "Ansible Testing", "roles": [{"href": "'"$role_id"'"}]}')
+pureport accounts consent -a "$account_id" accept > /dev/null
+network_id=$(pureport accounts networks -a "$account_id" create '{"name": "Ansible Testing"}' | jq  -r '.id')
+role_id=$(pureport accounts roles -a "$account_id" list | jq -r '.[0].id')
+api_key=$(pureport accounts api-keys -a "$account_id" create '{"name": "Ansible Testing", "roles": [{"href": "'"$role_id"'"}]}')
 api_key_key=$(echo "$api_key" | jq -r '.key')
 api_key_secret=$(echo "$api_key" | jq -r '.secret')
 


### PR DESCRIPTION
##### SUMMARY
This removes a lot of redundancy in error handling.  Initially, we were passing the Ansible module instance to a variety of methods, and within those methods, if they threw an error we fail the module.

Instead, it's much simpler to let any Python exceptions bubble out of the method and have a single except clause to handle the exception -> failure.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
