### PR TITLE
Correct ansible lint errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox
-          pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
+          pip install ansible
 
       - name: Run tox
         working-directory: ./ansible_collections/pureport

--- a/fabric/plugins/modules/access_token_info.py
+++ b/fabric/plugins/modules/access_token_info.py
@@ -19,7 +19,7 @@ module: access_token_info
 short_description: Retrieve an access token to use with the Pureport API
 description:
     - "Retrieve an access token to use with the Pureport API"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 options:

--- a/fabric/plugins/modules/accounts_info.py
+++ b/fabric/plugins/modules/accounts_info.py
@@ -19,7 +19,7 @@ module: accounts_info
 short_description: Retrieve a list of accounts for the given api credentials
 description:
     - "Retrieve a list of accounts for the given api credentials"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 extends_documentation_fragment:

--- a/fabric/plugins/modules/aws_direct_connect_connection.py
+++ b/fabric/plugins/modules/aws_direct_connect_connection.py
@@ -19,7 +19,7 @@ module: aws_direct_connect_connection
 short_description: Create, update or delete an AWS Direct Connect connection
 description:
     - "Create, update or delete an AWS Direct Connect connection"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 options:

--- a/fabric/plugins/modules/azure_express_route_connection.py
+++ b/fabric/plugins/modules/azure_express_route_connection.py
@@ -19,7 +19,7 @@ module: azure_express_route_connection
 short_description: Create, update or delete a Azure Express Route connection
 description:
     - "Create, update or delete a Azure Express Route connection"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 options:

--- a/fabric/plugins/modules/cloud_regions_info.py
+++ b/fabric/plugins/modules/cloud_regions_info.py
@@ -19,7 +19,7 @@ module: cloud_regions_info
 short_description: Retrieve a list of cloud regions
 description:
     - "Retrieve a list of cloud regions"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 extends_documentation_fragment:

--- a/fabric/plugins/modules/cloud_services_info.py
+++ b/fabric/plugins/modules/cloud_services_info.py
@@ -19,7 +19,7 @@ module: cloud_services_info
 short_description: Retrieve a list of cloud services
 description:
     - "Retrieve a list of cloud services"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 extends_documentation_fragment:

--- a/fabric/plugins/modules/connections_info.py
+++ b/fabric/plugins/modules/connections_info.py
@@ -19,7 +19,7 @@ module: connections_info
 short_description: Retrieve a list of connections for a account or network
 description:
     - "Retrieve a list of connections for a account or network"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 options:

--- a/fabric/plugins/modules/facilities_info.py
+++ b/fabric/plugins/modules/facilities_info.py
@@ -19,7 +19,7 @@ module: facilities_info
 short_description: Retrieve a list of facilities
 description:
     - "Retrieve a list of facilities"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 extends_documentation_fragment:

--- a/fabric/plugins/modules/google_cloud_interconnect_connection.py
+++ b/fabric/plugins/modules/google_cloud_interconnect_connection.py
@@ -19,7 +19,7 @@ module: google_cloud_interconnect_connection
 short_description: Create, update or delete a Google Cloud Interconnect connection
 description:
     - "Create, update or delete a Google Cloud Interconnect connection"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 options:

--- a/fabric/plugins/modules/locations_info.py
+++ b/fabric/plugins/modules/locations_info.py
@@ -19,7 +19,7 @@ module: locations_info
 short_description: Retrieve a list of locations
 description:
     - "Retrieve a list of locations"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 extends_documentation_fragment:

--- a/fabric/plugins/modules/network.py
+++ b/fabric/plugins/modules/network.py
@@ -19,7 +19,7 @@ module: network
 short_description: Create, update or delete a network
 description:
     - "Create, update or delete a network"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 options:

--- a/fabric/plugins/modules/networks_info.py
+++ b/fabric/plugins/modules/networks_info.py
@@ -19,7 +19,7 @@ module: networks_info
 short_description: Retrieve a list of networks for an account
 description:
     - "Retrieve a list of networks for an account"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 extends_documentation_fragment:

--- a/fabric/plugins/modules/options_info.py
+++ b/fabric/plugins/modules/options_info.py
@@ -19,7 +19,7 @@ module: options_info
 short_description: Retrieve a list of option enumerations used for creating connections
 description:
     - "Retrieve a list of option enumerations used for creating connections"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 options:

--- a/fabric/plugins/modules/oracle_fast_connect_connection.py
+++ b/fabric/plugins/modules/oracle_fast_connect_connection.py
@@ -19,7 +19,7 @@ module: oracle_fast_connect_connection
 short_description: Create, update or delete an Oracle Fast Connect connection
 description:
     - "Create, update or delete an Oracle Fast Connect connection"
-version_added: "2.9"
+version_added: "2.9.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 options:

--- a/fabric/plugins/modules/port.py
+++ b/fabric/plugins/modules/port.py
@@ -19,7 +19,7 @@ module: port
 short_description: Create, update or delete a port
 description:
     - "Create, update or delete a port"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 options:

--- a/fabric/plugins/modules/port_connection.py
+++ b/fabric/plugins/modules/port_connection.py
@@ -19,7 +19,7 @@ module: port_connection
 short_description: Create, update or delete a Port connection
 description:
     - "Create, update or delete a Port connection"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 options:

--- a/fabric/plugins/modules/ports_info.py
+++ b/fabric/plugins/modules/ports_info.py
@@ -19,7 +19,7 @@ module: ports_info
 short_description: Retrieve a list of ports for an account
 description:
     - "Retrieve a list of ports for an account"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 extends_documentation_fragment:

--- a/fabric/plugins/modules/site_ipsec_vpn_connection.py
+++ b/fabric/plugins/modules/site_ipsec_vpn_connection.py
@@ -19,7 +19,7 @@ module: site_ipsec_vpn_connection
 short_description: Create, update or delete a Site IPSec VPN connection
 description:
     - "Create, update or delete a Site IPSec VPN connection"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 options:

--- a/fabric/plugins/modules/supported_connections_info.py
+++ b/fabric/plugins/modules/supported_connections_info.py
@@ -19,7 +19,7 @@ module: supported_connections_info
 short_description: Retrieve a list of supported connections for an account
 description:
     - "Retrieve a list of supported connections for an account"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 extends_documentation_fragment:

--- a/fabric/plugins/modules/supported_ports_info.py
+++ b/fabric/plugins/modules/supported_ports_info.py
@@ -19,7 +19,7 @@ module: supported_ports_info
 short_description: Retrieve a list of supported ports for an account
 description:
     - "Retrieve a list of supported ports for an account"
-version_added: "2.8"
+version_added: "2.8.0"
 requirements: [ pureport-client ]
 author: Matt Traynham (@mtraynham)
 options:


### PR DESCRIPTION
##### SUMMARY
Corrects the version added errors seen in some of the latest builds

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
```paste below
ERROR: plugins/modules/facilities_info.py:0:0: module-invalid-version-added: DOCUMENTATION.version_added: invalid semantic version '2.8' for dictionary value @ data['version_added']. Got 'pureport.fabric:2.8'
ERROR: plugins/modules/google_cloud_interconnect_connection.py:0:0: module-invalid-version-added: DOCUMENTATION.version_added: invalid semantic version '2.8' for dictionary value @ data['version_added']. Got 'pureport.fabric:2.8'
ERROR: plugins/modules/locations_info.py:0:0: module-invalid-version-added: DOCUMENTATION.version_added: invalid semantic version '2.8' for dictionary value @ data['version_added']. Got 'pureport.fabric:2.8'
ERROR: plugins/modules/network.py:0:0: module-invalid-version-added: DOCUMENTATION.version_added: invalid semantic version '2.8' for dictionary value @ data['version_added']. Got 'pureport.fabric:2.8'
ERROR: plugins/modules/networks_info.py:0:0: module-invalid-version-added: DOCUMENTATION.version_added: invalid semantic version '2.8' for dictionary value @ data['version_added']. Got 'pureport.fabric:2.8'
ERROR: plugins/modules/options_info.py:0:0: module-invalid-version-added: DOCUMENTATION.version_added: invalid semantic version '2.8' for dictionary value @ data['version_added']. Got 'pureport.fabric:2.8'
ERROR: plugins/modules/oracle_fast_connect_connection.py:0:0: module-invalid-version-added: DOCUMENTATION.version_added: invalid semantic version '2.9' for dictionary value @ data['version_added']. Got 'pureport.fabric:2.9'
ERROR: plugins/modules/port.py:0:0: module-invalid-version-added: DOCUMENTATION.version_added: invalid semantic version '2.8' for dictionary value @ data['version_added']. Got 'pureport.fabric:2.8'
```
